### PR TITLE
Track ticket #3 blocker + TanStack Query setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ is the single lockfile for this repo.
 ```
 src/
   components/   shared UI components
-  lib/          shared utilities/helpers
+  hooks/        shared hooks (useApiQuery/useApiMutation, etc.)
+  lib/          shared utilities/helpers (query client, query-key factory)
   pages/        route-level page components
+  providers/    app-level context providers (QueryProvider, etc.)
   routes/       React Router route definitions
 ```
 
@@ -72,6 +74,48 @@ Tailwind CSS v4, config lives in `src/index.css` via `@theme` — there is no
   access needs to confirm/replace these against the real file.
 - Font is DM Sans (`@fontsource-variable/dm-sans`), matching
   `compassion-landing-page`'s `next/font` choice.
+
+## Data fetching (TanStack Query)
+
+All server data — Strapi and the Golang API alike, once the client modules
+in Ticket #3 land (blocked, see `TODO.md`) — goes through
+[TanStack Query](https://tanstack.com/query), not raw `fetch`/`useEffect`.
+
+- **Never call `useQuery`/`useMutation` directly.** Use the wrapper hooks
+  in `src/hooks/`: `useApiQuery` for reads, `useApiMutation` for writes.
+  They exist so app-wide defaults (`staleTime`, `retry`, cache
+  invalidation — see `src/lib/query-client.ts`) live in one place instead
+  of being repeated, and drifting, at every call site.
+- **Query keys come from `src/lib/query-keys.ts`.** Don't hand-write a key
+  array inline — add a branch to the `queryKeys` factory instead. This is
+  what keeps `useApiMutation`'s `invalidateKeys` in sync with the queries
+  it's supposed to invalidate.
+- **One hook per resource.** Wrap each API client function in its own
+  named hook (e.g. `useCourses()`, `useUserStats()`) rather than calling
+  `useApiQuery` ad hoc inside components. Put the hook next to the
+  component(s) that use it, or in `src/hooks/` if it's shared.
+- **Mutations declare `invalidateKeys`.** Any mutation that changes server
+  state passes the query keys that should refetch afterward — don't
+  manually refetch or reload the page instead.
+- **No fetching in `useEffect`.** If data is needed before render, use the
+  query's `isLoading`/`isPending` state (or a route loader later), not a
+  manual effect + `useState`.
+- **Errors are surfaced, not swallowed.** Read `error`/`isError` off the
+  hook and let the component decide how to render it — don't catch and
+  discard in the query/mutation function.
+
+Example, once a real API function exists:
+
+```ts
+// src/hooks/useCourses.ts
+import { getCourses } from '@/lib/api/strapi'
+import { useApiQuery } from '@/hooks/useApiQuery'
+import { queryKeys } from '@/lib/query-keys'
+
+export function useCourses() {
+  return useApiQuery(queryKeys.courses(), getCourses)
+}
+```
 
 ## Git Workflow
 

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,12 @@ prevent.
 auth, course list/detail, user courses/stats/activities, lessons,
 certificates, checkout) from whoever owns the SDS.
 
+**Already done ahead of the client modules themselves:** TanStack Query is
+installed and wired up (`QueryProvider`, `queryClient`, `queryKeys`
+factory, `useApiQuery`/`useApiMutation` wrapper hooks) — see the README
+"Data fetching" section. Once §6 lands and the Strapi/Golang client
+functions exist, they plug straight into these wrappers.
+
 **What we already have, ready to use once §6 lands:**
 
 - §4 `lms` database schema (`users`, `password_reset_tokens`, `enrollments`,

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,49 @@
+# TODO / Blocked work
+
+Tracks work that can't be finished yet because it's waiting on something
+outside this repo, so it doesn't get lost between sessions.
+
+## Ticket #3 — API client scaffolding: blocked on SDS §6
+
+**Status:** blocked, not started.
+
+Ticket #3 (`API client scaffolding`) requires every client function's return
+type to match its corresponding **SDS §6 response shape exactly** (e.g.
+`login()` -> §6.1, `getUserStats()` -> §6.3). We don't have §6 — only §4
+(Database Schemas) and §5 (API Design / endpoint list) have been shared so
+far, and those don't specify response body field names/casing.
+
+**Why not just infer it from §4/§5:** §4/§5 give the DB columns and the
+endpoint list, not the JSON response contract (field names, casing,
+nesting, what's included vs. omitted). Guessing here risks every downstream
+feature ticket (Epics 1-6) being built against types that don't match the
+real backend once it exists, which is exactly what Ticket #3 exists to
+prevent.
+
+**What's needed to unblock:** SDS §6 (the response-shape reference for
+auth, course list/detail, user courses/stats/activities, lessons,
+certificates, checkout) from whoever owns the SDS.
+
+**What we already have, ready to use once §6 lands:**
+
+- §4 `lms` database schema (`users`, `password_reset_tokens`, `enrollments`,
+  `certificates`, `transactions`) — Golang-owned.
+- §4 `strapi` database content-types (`course`, `trainer`, `article`, etc.)
+  — Strapi-owned, served via its own content API.
+- §5 endpoint list for the Golang backend (`/api/v1/auth/*`,
+  `/api/v1/user/*`, `/api/v1/courses/{id}/lessons/{index}`,
+  `/api/v1/certificates`, `/api/v1/checkout`, `/api/v1/webhook/midtrans`).
+
+**Todos (from the ticket, unstarted):**
+
+- [ ] Get SDS §6 from the SDS owner
+- [ ] Define TypeScript types for every SDS §6 response shape
+- [ ] Build Strapi client module (`getCourses`, `getCourseBySlug`,
+      `getSiteConfig`, etc.)
+- [ ] Build Golang client module (`login`, `register`, `getMe`, `logout`,
+      `getUserCourses`, `getUserStats`, `getUserActivities`, `getLesson`,
+      `getCertificates`, `checkout`)
+- [ ] Add CSRF token handling + `credentials: include` to the Golang client
+      wrapper
+- [ ] Add `.env.example` with `VITE_STRAPI_URL`, `VITE_STRAPI_TOKEN`,
+      `VITE_API_URL`

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@fontsource-variable/dm-sans": "^5.3.0",
+    "@tanstack/react-query": "^5.102.8",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-router-dom": "^7.18.3"
@@ -21,6 +22,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tailwindcss/vite": "^4.3.3",
+    "@tanstack/react-query-devtools": "^5.102.8",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
       '@fontsource-variable/dm-sans':
         specifier: ^5.3.0
         version: 5.3.0
+      '@tanstack/react-query':
+        specifier: ^5.102.8
+        version: 5.102.8(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -26,6 +29,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0))
+      '@tanstack/react-query-devtools':
+        specifier: ^5.102.8
+        version: 5.102.8(@tanstack/react-query@5.102.8(react@19.2.8))(react@19.2.8)
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
@@ -638,6 +644,35 @@ packages:
       }
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/query-core@5.102.8':
+    resolution:
+      {
+        integrity: sha512-ZNjkJ33CqvPNec/6lZBnHqLc3EVGPZ9ySLhYahU9TcuRFdmwXewuj0c4hwSWcGHqEUwcSrKeZ+oGcvPBqXcQcg==,
+      }
+
+  '@tanstack/query-devtools@5.102.8':
+    resolution:
+      {
+        integrity: sha512-ZgeMKuF5d/zOE+tgWm3cSbD6Zcbr6IugVsnbHzUcSismqLZDSUPBKM6ILUxExgwe6rPAOox2x5bA5T+PSOQG0Q==,
+      }
+
+  '@tanstack/react-query-devtools@5.102.8':
+    resolution:
+      {
+        integrity: sha512-QKb7A44BZOU7nxsGA4gFN1fofjYovar5O0T83Ff4Y+2eRq09RGFrAzzutVdF/6/emfSaMDohp6e759BjB3fxEw==,
+      }
+    peerDependencies:
+      '@tanstack/react-query': ^5.102.8
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.102.8':
+    resolution:
+      {
+        integrity: sha512-TYBea4OuXWD7MhaSHq069TWbFe7rcwWN6kzT7JF0OKi1K6c1gTv2IzD6A6ExJsCMozdkqBWeuIUZmu4KQg0O5A==,
+      }
+    peerDependencies:
+      react: ^18 || ^19
 
   '@types/esrecurse@4.3.1':
     resolution:
@@ -2161,6 +2196,21 @@ snapshots:
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
       vite: 8.2.2(@types/node@24.13.3)(jiti@2.7.0)
+
+  '@tanstack/query-core@5.102.8': {}
+
+  '@tanstack/query-devtools@5.102.8': {}
+
+  '@tanstack/react-query-devtools@5.102.8(@tanstack/react-query@5.102.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-devtools': 5.102.8
+      '@tanstack/react-query': 5.102.8(react@19.2.8)
+      react: 19.2.8
+
+  '@tanstack/react-query@5.102.8(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-core': 5.102.8
+      react: 19.2.8
 
   '@types/esrecurse@4.3.1': {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,14 @@
 import { RouterProvider } from 'react-router-dom'
 
+import { QueryProvider } from '@/providers/QueryProvider'
 import { router } from '@/routes'
 
 function App() {
-  return <RouterProvider router={router} />
+  return (
+    <QueryProvider>
+      <RouterProvider router={router} />
+    </QueryProvider>
+  )
 }
 
 export default App

--- a/src/hooks/useApiMutation.ts
+++ b/src/hooks/useApiMutation.ts
@@ -1,0 +1,39 @@
+import {
+  useMutation,
+  useQueryClient,
+  type QueryKey,
+  type UseMutationOptions,
+} from '@tanstack/react-query'
+
+interface UseApiMutationOptions<TData, TVariables> extends UseMutationOptions<
+  TData,
+  Error,
+  TVariables
+> {
+  /** Query keys to invalidate after a successful mutation. */
+  invalidateKeys?: QueryKey[]
+}
+
+/**
+ * Thin wrapper around useMutation. Use this (not useMutation directly) for
+ * every write to the Strapi/Golang clients, so cache invalidation is
+ * declared next to the mutation instead of scattered across call sites.
+ * See the README "Data fetching" section for the full rules.
+ */
+export function useApiMutation<TData, TVariables>(
+  mutationFn: (variables: TVariables) => Promise<TData>,
+  { invalidateKeys, onSuccess, ...options }: UseApiMutationOptions<TData, TVariables> = {},
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn,
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      invalidateKeys?.forEach((queryKey) => {
+        void queryClient.invalidateQueries({ queryKey })
+      })
+      onSuccess?.(data, variables, onMutateResult, context)
+    },
+  })
+}

--- a/src/hooks/useApiQuery.ts
+++ b/src/hooks/useApiQuery.ts
@@ -1,0 +1,19 @@
+import { useQuery, type QueryKey, type UseQueryOptions } from '@tanstack/react-query'
+
+/**
+ * Thin wrapper around useQuery. Use this (not useQuery directly) for every
+ * read from the Strapi/Golang clients, so app-wide defaults (staleTime,
+ * retry — see src/lib/query-client.ts) stay in one place. See the README
+ * "Data fetching" section for the full rules.
+ */
+export function useApiQuery<TData, TKey extends QueryKey = QueryKey>(
+  queryKey: TKey,
+  queryFn: () => Promise<TData>,
+  options?: Omit<UseQueryOptions<TData, Error, TData, TKey>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery({
+    queryKey,
+    queryFn,
+    ...options,
+  })
+}

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -1,0 +1,18 @@
+import { QueryClient } from '@tanstack/react-query'
+
+/**
+ * Single QueryClient instance for the app. Import this (or the wrapper
+ * hooks in src/hooks/) rather than constructing another QueryClient.
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+})

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -1,0 +1,25 @@
+/**
+ * Central query-key factory. Every useApiQuery call gets its key from here
+ * instead of a hand-written array, so invalidation (see useApiMutation's
+ * `invalidateKeys`) can't drift out of sync with the keys queries actually
+ * use.
+ *
+ * Add a branch here per resource as its API client function lands
+ * (blocked on SDS §6 — see TODO.md). Keep the nesting shallow: one level
+ * per resource, params only on the leaf.
+ */
+export const queryKeys = {
+  all: ['api'] as const,
+
+  auth: () => [...queryKeys.all, 'auth'] as const,
+  me: () => [...queryKeys.auth(), 'me'] as const,
+
+  courses: () => [...queryKeys.all, 'courses'] as const,
+  course: (slug: string) => [...queryKeys.courses(), slug] as const,
+
+  userCourses: () => [...queryKeys.all, 'user', 'courses'] as const,
+  userStats: () => [...queryKeys.all, 'user', 'stats'] as const,
+  userActivities: () => [...queryKeys.all, 'user', 'activities'] as const,
+
+  certificates: () => [...queryKeys.all, 'certificates'] as const,
+}

--- a/src/providers/QueryProvider.tsx
+++ b/src/providers/QueryProvider.tsx
@@ -1,0 +1,14 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import type { ReactNode } from 'react'
+
+import { queryClient } from '@/lib/query-client'
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+    </QueryClientProvider>
+  )
+}


### PR DESCRIPTION
Refs #3 (not closing — ticket is blocked, not done)

**Blocker tracking:**
Ticket #3 needs every client function's return type to match SDS §6
response shapes exactly. We only have §4 (DB schemas) and §5 (endpoint
list) so far — §6 (the actual response body shapes) hasn't been shared.
Building the client modules against inferred shapes risks a mismatch with
the real backend, which is the exact thing this ticket exists to prevent.
Added `TODO.md` to track this so it's picked back up once §6 lands.

**TanStack Query setup (ahead of the blocked client modules):**
- Installed `@tanstack/react-query` + devtools
- `QueryProvider` wraps the app; `queryClient` centralizes default
  staleTime/retry; `queryKeys` factory for consistent, invalidatable keys
- `useApiQuery` / `useApiMutation` wrapper hooks in `src/hooks/`
- README "Data fetching" section documents the rules: use the wrappers
  (not raw `useQuery`/`useMutation`), keys from the factory, one hook per
  resource, mutations declare `invalidateKeys`, no fetching in `useEffect`

Once §6 lands, the Strapi/Golang client functions plug straight into this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qh4T3NXHsA3Zq8j8RTjwYR