### PR TITLE
Shared component library

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,33 @@ Tailwind CSS v4, config lives in `src/index.css` via `@theme` — there is no
 - `--color-primary` (`#84c6da`) and `--color-accent` (`#faea05`) are pulled
   from the same Figma file as `compassion-landing-page` (see that repo's
   `globals.css`) — not eyeballed.
-- Status colors (`--color-success`, `--color-info`, `--color-warning`), the
-  type scale (`--text-display`/`h2`/`h3`/`stat`), radius (`--radius-card`,
-  `--radius-control`), and `--shadow-card` are eyeballed from the dashboard
-  mockups (Images 1-9), **not** pulled from Figma yet — this repo doesn't
-  have Figma Editor access. Flagging per Ticket 2: someone with Editor
-  access needs to confirm/replace these against the real file.
+- Status colors (`--color-success`, `--color-info`, `--color-warning`,
+  `--color-highlight`), the type scale (`--text-display`/`h2`/`h3`/`stat`),
+  radius (`--radius-card`, `--radius-control`), and `--shadow-card` are
+  eyeballed from the dashboard mockups (Images 1-9), **not** pulled from
+  Figma yet — this repo doesn't have Figma Editor access. Flagging per
+  Ticket 2: someone with Editor access needs to confirm/replace these
+  against the real file.
 - Font is DM Sans (`@fontsource-variable/dm-sans`), matching
   `compassion-landing-page`'s `next/font` choice.
+
+## Component library
+
+Shared, reusable UI components live in `src/components/`. Visit
+`/style-guide` for a live reference of every component and variant.
+
+- `Button` — `primary` / `accent` / `outline` / `success` variants.
+  `success` isn't in Ticket #6's original list; added to match the
+  Purchases mockup's green "View Certificate" CTA.
+- `StatusBadge` — `completed` / `in-progress` / `not-started`.
+- `ProgressBar` — colored by the same `Status` as `StatusBadge`, so a
+  course's badge and bar always agree.
+- `StatCard` — plain (dashboard) or with an `icon` (purchases-page style).
+- `CourseCard` — `catalog` | `purchased` variant via a discriminated union
+  (`CourseCard.types.ts`). **`catalog` is inferred, not pixel-matched** —
+  none of the provided mockups show it; Ticket #21 should refine it.
+  `purchased` matches the My Purchases mockup.
+- `EmptyState` — icon + heading + subtext + optional CTA.
 
 ## Data fetching (TanStack Query)
 

--- a/TODO.md
+++ b/TODO.md
@@ -120,3 +120,31 @@ change, only the types they consume.
 `ProtectedRoute`) since it reads as a public catalog page and the login
 page mockup has an "Explore Online Courses" CTA for guests — this isn't
 stated in any ticket, just inferred from the mockups.
+
+## Ticket #6 — Shared component library: done with inferred assumptions
+
+**Status:** done.
+
+Built `Button`, `StatusBadge`, `ProgressBar`, `StatCard`, `CourseCard`
+(catalog/purchased via a discriminated union in `CourseCard.types.ts`),
+and `EmptyState` in `src/components/`. All shown live on `/style-guide`.
+
+**Assumptions worth flagging (not spec'd anywhere):**
+
+- Added a `success` `Button` variant beyond the ticket's named list
+  (primary/accent/outline), to match the Purchases mockup's green "View
+  Certificate" CTA — using `accent` (yellow) or `primary` for it would
+  have been visually wrong.
+- Added `--color-highlight` (`#a855f7`, eyeballed) to `src/index.css` for
+  the dashboard's 4th stat card ("My Certificates", purple) — no existing
+  token fit. Same "needs Figma confirmation" caveat as the rest of Ticket
+  2's palette.
+- `CourseCard`'s `catalog` variant is **inferred, not pixel-matched** —
+  none of the 6 provided screenshots show the public catalog card, only
+  the purchased-course variant (My Purchases page). Built a plausible
+  banner + price + "View Course" layout; Ticket #21 ("Course card —
+  catalog variant") should replace/confirm it against the real design.
+- `CourseCard` banners use plain Tailwind background colors
+  (`bannerClassName` prop, e.g. `bg-indigo-600`) as a placeholder for the
+  real banner artwork/images seen in the mockups — no asset pipeline
+  exists yet for those.

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,29 @@
+import type { ButtonHTMLAttributes } from 'react'
+
+/**
+ * `success` isn't in Ticket #6's todo list (primary/accent/outline only)
+ * but the Purchases mockup's "View Certificate" CTA is a distinct green
+ * button — added to match the screenshot rather than force it into an
+ * existing variant. Flagged in TODO.md.
+ */
+export type ButtonVariant = 'primary' | 'accent' | 'outline' | 'success'
+
+const variantClassName: Record<ButtonVariant, string> = {
+  primary: 'bg-primary text-white hover:opacity-90',
+  accent: 'bg-accent text-foreground hover:opacity-90',
+  success: 'bg-success text-white hover:opacity-90',
+  outline: 'border border-primary text-primary hover:bg-primary/10',
+}
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+}
+
+export function Button({ variant = 'primary', className = '', ...props }: ButtonProps) {
+  return (
+    <button
+      className={`rounded-control px-4 py-2 text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${variantClassName[variant]} ${className}`}
+      {...props}
+    />
+  )
+}

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -1,0 +1,68 @@
+import { Button, type ButtonVariant } from '@/components/Button'
+import type { CourseCardProps } from '@/components/CourseCard.types'
+import { ProgressBar } from '@/components/ProgressBar'
+import type { Status } from '@/components/StatusBadge'
+import { StatusBadge } from '@/components/StatusBadge'
+
+const ctaVariantByStatus: Record<Status, ButtonVariant> = {
+  'in-progress': 'primary',
+  completed: 'success',
+  'not-started': 'accent',
+}
+
+function formatIdr(amount: number): string {
+  return `Rp ${amount.toLocaleString('id-ID')}`
+}
+
+/**
+ * `catalog` variant is inferred, not pixel-matched to a mockup — none of
+ * the provided screenshots show the public catalog card. Ticket #21
+ * ("Course card — catalog variant") should refine it. `purchased` matches
+ * the My Purchases mockup.
+ */
+export function CourseCard(props: CourseCardProps) {
+  return (
+    <div className="overflow-hidden rounded-card shadow-card border border-border bg-background">
+      <div className={`flex h-40 flex-col justify-end p-4 text-white ${props.bannerClassName}`}>
+        <p className="text-h3 font-bold">{props.title}</p>
+        <p className="text-sm opacity-90">{props.instructorName}</p>
+      </div>
+
+      <div className="space-y-3 p-4">
+        <p className="text-h3 font-semibold">{props.title}</p>
+        <p className="text-sm text-muted">By {props.instructorName}</p>
+
+        {props.variant === 'catalog' ? (
+          <>
+            <p className="text-sm text-muted">{props.instructorRole}</p>
+            <p className="font-semibold">{formatIdr(props.price)}</p>
+            <Button variant="primary" className="w-full">
+              View Course
+            </Button>
+          </>
+        ) : (
+          <>
+            <div className="flex items-center justify-between text-sm text-muted">
+              <span>
+                {props.completedModules}/{props.moduleCount} Module Videos
+              </span>
+              <span>{props.durationLabel}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <StatusBadge status={props.status} />
+              <span className="text-sm font-semibold">{props.progress}%</span>
+            </div>
+            <ProgressBar value={props.progress} status={props.status} />
+            <Button
+              variant={ctaVariantByStatus[props.status]}
+              className="w-full"
+              onClick={props.onCtaClick}
+            >
+              {props.ctaLabel}
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/CourseCard.types.ts
+++ b/src/components/CourseCard.types.ts
@@ -1,0 +1,30 @@
+import type { Status } from '@/components/StatusBadge'
+
+interface CourseCardBase {
+  slug: string
+  title: string
+  instructorName: string
+  /** Tailwind background utility for the banner block, e.g. 'bg-indigo-600'. Real banner images aren't available yet — see TODO.md. */
+  bannerClassName: string
+}
+
+export interface CatalogCourseCardProps extends CourseCardBase {
+  variant: 'catalog'
+  instructorRole: string
+  /** IDR */
+  price: number
+}
+
+export interface PurchasedCourseCardProps extends CourseCardBase {
+  variant: 'purchased'
+  completedModules: number
+  moduleCount: number
+  durationLabel: string
+  status: Status
+  /** 0-100 */
+  progress: number
+  ctaLabel: string
+  onCtaClick?: () => void
+}
+
+export type CourseCardProps = CatalogCourseCardProps | PurchasedCourseCardProps

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react'
+
+interface EmptyStateProps {
+  icon: ReactNode
+  heading: string
+  subtext: string
+  /** Pass a <Button> (or <Link>) — the CTA's own styling stays with the caller. */
+  cta?: ReactNode
+}
+
+export function EmptyState({ icon, heading, subtext, cta }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-card border border-dashed border-border p-12 text-center">
+      <div className="text-4xl text-muted" aria-hidden="true">
+        {icon}
+      </div>
+      <h3 className="text-h3 font-semibold">{heading}</h3>
+      <p className="max-w-sm text-sm text-muted">{subtext}</p>
+      {cta}
+    </div>
+  )
+}

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,32 @@
+import type { Status } from '@/components/StatusBadge'
+
+const fillClassName: Record<Status, string> = {
+  completed: 'bg-success',
+  'in-progress': 'bg-info',
+  'not-started': 'bg-warning',
+}
+
+interface ProgressBarProps {
+  /** 0-100 */
+  value: number
+  status: Status
+}
+
+export function ProgressBar({ value, status }: ProgressBarProps) {
+  const clamped = Math.min(100, Math.max(0, value))
+
+  return (
+    <div
+      className="h-2 w-full overflow-hidden rounded-full bg-border"
+      role="progressbar"
+      aria-valuenow={clamped}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <div
+        className={`h-full rounded-full ${fillClassName[status]}`}
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  )
+}

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react'
+
+export type StatCardColor = 'primary' | 'accent' | 'success' | 'highlight'
+
+const valueClassName: Record<StatCardColor, string> = {
+  primary: 'text-primary',
+  accent: 'text-accent',
+  success: 'text-success',
+  highlight: 'text-highlight',
+}
+
+const iconClassName: Record<StatCardColor, string> = {
+  primary: 'bg-primary/10 text-primary',
+  accent: 'bg-accent/10 text-accent',
+  success: 'bg-success/10 text-success',
+  highlight: 'bg-highlight/10 text-highlight',
+}
+
+interface StatCardProps {
+  label: string
+  value: ReactNode
+  color?: StatCardColor
+  /** Helper text under the value, e.g. "+1 this month" (dashboard variant). */
+  helperText?: string
+  /** Icon in a colored square above the label (purchases-page variant). Omit for the plain dashboard style. */
+  icon?: ReactNode
+}
+
+export function StatCard({ label, value, color = 'primary', helperText, icon }: StatCardProps) {
+  return (
+    <div className="rounded-card shadow-card border border-border bg-background p-6">
+      {icon ? (
+        <div
+          className={`mb-3 flex h-10 w-10 items-center justify-center rounded-control ${iconClassName[color]}`}
+        >
+          {icon}
+        </div>
+      ) : null}
+      <p className="text-sm text-muted">{label}</p>
+      <p className={`text-stat font-bold ${valueClassName[color]}`}>{value}</p>
+      {helperText ? <p className="mt-1 text-sm text-muted">{helperText}</p> : null}
+    </div>
+  )
+}

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,0 +1,23 @@
+export type Status = 'completed' | 'in-progress' | 'not-started'
+
+const statusConfig: Record<Status, { label: string; className: string }> = {
+  completed: { label: 'Completed', className: 'bg-success/10 text-success' },
+  'in-progress': { label: 'In Progress', className: 'bg-info/10 text-info' },
+  'not-started': { label: 'Not Started', className: 'bg-warning/10 text-warning' },
+}
+
+interface StatusBadgeProps {
+  status: Status
+}
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  const { label, className } = statusConfig[status]
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${className}`}
+    >
+      {label}
+    </span>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,7 @@
   --color-success: #22c55e;
   --color-info: #3b82f6;
   --color-warning: #eab308;
+  --color-highlight: #a855f7; /* dashboard "My Certificates" stat — eyeballed, no clear brand role yet */
 
   --color-border: #e5e7eb;
   --color-muted: #6b7280;
@@ -31,6 +32,7 @@
   --color-success: var(--color-success);
   --color-info: var(--color-info);
   --color-warning: var(--color-warning);
+  --color-highlight: var(--color-highlight);
   --color-border: var(--color-border);
   --color-muted: var(--color-muted);
 

--- a/src/pages/StyleGuide.tsx
+++ b/src/pages/StyleGuide.tsx
@@ -1,9 +1,19 @@
+import { Button } from '@/components/Button'
+import { CourseCard } from '@/components/CourseCard'
+import { EmptyState } from '@/components/EmptyState'
+import { ProgressBar } from '@/components/ProgressBar'
+import { StatCard } from '@/components/StatCard'
+import { StatusBadge, type Status } from '@/components/StatusBadge'
+
+const statuses: Status[] = ['in-progress', 'completed', 'not-started']
+
 const colorTokens = [
   { name: 'primary', className: 'bg-primary', hex: '#84c6da' },
   { name: 'accent', className: 'bg-accent', hex: '#faea05' },
   { name: 'success', className: 'bg-success', hex: '#22c55e' },
   { name: 'info', className: 'bg-info', hex: '#3b82f6' },
   { name: 'warning', className: 'bg-warning', hex: '#eab308' },
+  { name: 'highlight', className: 'bg-highlight', hex: '#a855f7' },
   { name: 'border', className: 'bg-border', hex: '#e5e7eb' },
   { name: 'muted', className: 'bg-muted', hex: '#6b7280' },
 ] as const
@@ -23,7 +33,7 @@ const typeScale = [
 
 export function StyleGuide() {
   return (
-    <div className="mx-auto max-w-3xl space-y-10 p-8">
+    <div className="mx-auto max-w-5xl space-y-10 p-8">
       <header>
         <h1 className="text-display font-bold">Style Guide</h1>
         <p className="text-sm text-muted mt-1">
@@ -68,6 +78,105 @@ export function StyleGuide() {
           <div className="rounded-control bg-primary h-16 w-16" />
           <div className="rounded-card shadow-card bg-white border border-border h-16 w-32" />
         </div>
+      </section>
+
+      <section>
+        <h2 className="text-h2 font-semibold mb-4">Buttons</h2>
+        <div className="flex flex-wrap gap-3">
+          <Button variant="primary">Primary</Button>
+          <Button variant="accent">Accent</Button>
+          <Button variant="success">Success</Button>
+          <Button variant="outline">Outline</Button>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-h2 font-semibold mb-4">Status badges</h2>
+        <div className="flex flex-wrap gap-3">
+          {statuses.map((status) => (
+            <StatusBadge key={status} status={status} />
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-h2 font-semibold mb-4">Progress bars</h2>
+        <div className="max-w-sm space-y-3">
+          {statuses.map((status) => (
+            <ProgressBar key={status} status={status} value={status === 'completed' ? 100 : 60} />
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-h2 font-semibold mb-4">Stat cards</h2>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <StatCard label="My Learning List" value={8} color="primary" helperText="+1 this month" />
+          <StatCard
+            label="Skills Unlocked"
+            value={6}
+            color="accent"
+            helperText="75% completion rate"
+          />
+          <StatCard label="Hours Learned" value={40} color="success" helperText="+1 this month" />
+          <StatCard
+            label="My Certificates"
+            value={5}
+            color="highlight"
+            helperText="1 certificate in review"
+          />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-h2 font-semibold mb-4">Course cards</h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <CourseCard
+            variant="purchased"
+            slug="fondasi-komunikasi"
+            title="Fondasi Komunikasi"
+            instructorName="Indra Herlambang"
+            bannerClassName="bg-indigo-600"
+            completedModules={4}
+            moduleCount={6}
+            durationLabel="18h 30m"
+            status="in-progress"
+            progress={60}
+            ctaLabel="Continue Course"
+          />
+          <CourseCard
+            variant="purchased"
+            slug="art-of-mc"
+            title="The Art of MC"
+            instructorName="Nadia Mulya"
+            bannerClassName="bg-pink-600"
+            completedModules={6}
+            moduleCount={6}
+            durationLabel="18h 30m"
+            status="completed"
+            progress={100}
+            ctaLabel="View Certificate"
+          />
+          <CourseCard
+            variant="catalog"
+            slug="how-to-be-a-great-mc"
+            title="How to Be A Great MC"
+            instructorName="Indra Herlambang"
+            instructorRole="MC | TV Host | Writer"
+            bannerClassName="bg-slate-700"
+            price={499000}
+          />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-h2 font-semibold mb-4">Empty state</h2>
+        <EmptyState
+          icon="📚"
+          heading="No courses yet"
+          subtext="You haven't purchased any courses. Explore the catalog to get started."
+          cta={<Button variant="primary">Explore Online Courses</Button>}
+        />
       </section>
     </div>
   )


### PR DESCRIPTION
Closes #6

- `Button` (primary/accent/outline + `success`, added to match the
  Purchases mockup's green "View Certificate" CTA — see TODO.md)
- `StatusBadge` (completed/in-progress/not-started)
- `ProgressBar` (colored by the same `Status` as `StatusBadge`)
- `StatCard` (plain dashboard style, or with an icon — purchases style)
- `CourseCard` with `catalog`/`purchased` variants via a discriminated
  union (`CourseCard.types.ts`)
- `EmptyState` (icon + heading + subtext + optional CTA)
- All shown live on `/style-guide`
- Added `--color-highlight` design token (purple, eyeballed) for the
  dashboard's 4th stat card — no existing token fit

**Assumptions flagged in TODO.md** (none of these are spec'd, just
inferred to make the components usable now):
- `CourseCard`'s `catalog` variant isn't in any provided mockup — built a
  plausible layout, flagged for Ticket #21 to confirm/replace
- `CourseCard` banners use plain Tailwind background colors as a
  placeholder for real banner artwork (no asset pipeline yet)
- `success` button variant added beyond the ticket's named list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qh4T3NXHsA3Zq8j8RTjwYR