### PR TITLE
App shell layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ Shared, reusable UI components live in `src/components/`. Visit
   `purchased` matches the My Purchases mockup.
 - `EmptyState` — icon + heading + subtext + optional CTA.
 
+## App shell
+
+`AppShell` (`src/components/AppShell.tsx`) is the single layout —
+sidebar + topbar + `<Outlet>` — wrapping every protected route via a
+parent route in `src/routes/index.tsx`. `Sidebar` highlights the active
+nav item and wires its logout button to `useAuth().logout()`; `Topbar`
+reads the current user from `useAuth()` (no hardcoded user data). Icons
+are a small hand-authored set in `src/components/icons.tsx` — no icon
+library added yet.
+
+`/explore` is intentionally outside the shell (no mockup shows an
+authenticated Explore page) — see `TODO.md` for why, and revisit
+alongside Ticket #20.
+
 ## Data fetching (TanStack Query)
 
 All server data — Strapi and the Golang API alike, once the client modules

--- a/TODO.md
+++ b/TODO.md
@@ -148,3 +148,27 @@ and `EmptyState` in `src/components/`. All shown live on `/style-guide`.
   (`bannerClassName` prop, e.g. `bg-indigo-600`) as a placeholder for the
   real banner artwork/images seen in the mockups — no asset pipeline
   exists yet for those.
+
+## Ticket #7 — App shell layout: done with an inferred assumption
+
+**Status:** done.
+
+Built `AppShell` (`src/components/AppShell.tsx`, sidebar + topbar +
+`<Outlet>`), `Sidebar`, `Topbar`, and a small hand-authored icon set
+(`src/components/icons.tsx` — no icon library added). Wired as a single
+parent route in `src/routes/index.tsx`: `<ProtectedRoute><AppShell /></ProtectedRoute>`
+wraps `/dashboard`, `/purchases`, `/settings`, `/courses/:courseId` as
+children, satisfying "single layout component wrapping all protected
+routes." Topbar's user info and Sidebar's logout button both go through
+`useAuth()` — no hardcoded user data.
+
+**Assumption worth flagging:** `/explore` was kept outside `AppShell`
+entirely (no sidebar/topbar), since none of the 6 provided screenshots
+show an authenticated Explore page and Ticket #7 scopes the shell to
+"authenticated screens." Revisit when Ticket #20 (Catalog page) is built —
+an authenticated user browsing Explore probably _should_ see the shell,
+which would mean moving it inside the `AppShell` children instead.
+
+**Not built (out of scope for this ticket, not asked for):** the language
+dropdown and notification bell are static placeholders — no real i18n
+switching or notification list exists yet.

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,0 +1,19 @@
+import { Outlet } from 'react-router-dom'
+
+import { Sidebar } from '@/components/Sidebar'
+import { Topbar } from '@/components/Topbar'
+
+/** Sidebar + topbar shared by every authenticated screen. Renders the matched child route via Outlet. */
+export function AppShell() {
+  return (
+    <div className="flex min-h-screen bg-border/10">
+      <Sidebar />
+      <div className="flex flex-1 flex-col">
+        <Topbar />
+        <main className="flex-1 p-6">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,64 @@
+import { NavLink } from 'react-router-dom'
+
+import {
+  CartIcon,
+  DashboardIcon,
+  GlobeIcon,
+  LogoIcon,
+  LogoutIcon,
+  SettingsIcon,
+} from '@/components/icons'
+import { useAuth } from '@/hooks/useAuth'
+
+const navItems = [
+  { to: '/dashboard', label: 'My Dashboard', icon: DashboardIcon },
+  { to: '/purchases', label: 'My Purchases', icon: CartIcon },
+  { to: '/explore', label: 'Explore Online Courses', icon: GlobeIcon },
+]
+
+const navItemClassName = ({ isActive }: { isActive: boolean }) =>
+  `flex items-center gap-3 rounded-control border-l-2 px-3 py-2 text-sm font-medium ${
+    isActive
+      ? 'border-primary bg-primary/10 text-primary'
+      : 'border-transparent text-muted hover:bg-border/50'
+  }`
+
+export function Sidebar() {
+  const { logout } = useAuth()
+
+  return (
+    <aside className="flex w-64 shrink-0 flex-col border-r border-border bg-background">
+      <div className="flex items-center gap-2 p-6">
+        <LogoIcon className="h-8 w-8 shrink-0 text-primary" />
+        <div>
+          <p className="font-bold leading-tight">CommPassion</p>
+          <p className="text-xs leading-tight text-muted">E-Learning Dashboard</p>
+        </div>
+      </div>
+
+      <nav className="flex-1 space-y-1 px-3">
+        {navItems.map(({ to, label, icon: NavIcon }) => (
+          <NavLink key={to} to={to} className={navItemClassName}>
+            <NavIcon className="h-5 w-5 shrink-0" />
+            {label}
+          </NavLink>
+        ))}
+      </nav>
+
+      <div className="space-y-1 border-t border-border px-3 py-4">
+        <NavLink to="/settings" className={navItemClassName}>
+          <SettingsIcon className="h-5 w-5 shrink-0" />
+          Settings
+        </NavLink>
+        <button
+          type="button"
+          onClick={() => void logout()}
+          className="flex w-full items-center gap-3 rounded-control border-l-2 border-transparent px-3 py-2 text-left text-sm font-medium text-muted hover:bg-border/50"
+        >
+          <LogoutIcon className="h-5 w-5 shrink-0" />
+          Logout
+        </button>
+      </div>
+    </aside>
+  )
+}

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -1,0 +1,44 @@
+import { BellIcon, ChevronDownIcon, SearchIcon } from '@/components/icons'
+import { useAuth } from '@/hooks/useAuth'
+
+/**
+ * Language dropdown and notification bell are visual placeholders here —
+ * actual i18n switching and a notifications list are their own scope, not
+ * this ticket's. The user dropdown is real: it reads from AuthContext.
+ */
+export function Topbar() {
+  const { user } = useAuth()
+
+  return (
+    <header className="flex items-center gap-4 border-b border-border bg-background px-6 py-4">
+      <div className="relative max-w-md flex-1">
+        <SearchIcon className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted" />
+        <input
+          type="search"
+          placeholder="Search modules, courses, or anything..."
+          className="w-full rounded-full border border-border bg-border/20 py-2 pr-4 pl-9 text-sm placeholder:text-muted focus:ring-2 focus:ring-primary/40 focus:outline-none"
+        />
+      </div>
+
+      <div className="ml-auto flex items-center gap-4">
+        <button type="button" className="flex items-center gap-1 text-sm font-medium text-muted">
+          EN
+          <ChevronDownIcon className="h-4 w-4" />
+        </button>
+
+        <button type="button" className="relative rounded-full border border-border p-2">
+          <BellIcon className="h-5 w-5 text-muted" />
+          <span className="absolute top-1.5 right-1.5 h-2 w-2 rounded-full bg-red-500" />
+        </button>
+
+        <button type="button" className="flex items-center gap-2">
+          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+            {user?.fullName.charAt(0) ?? '?'}
+          </span>
+          <span className="text-sm font-medium">{user?.fullName ?? 'Guest'}</span>
+          <ChevronDownIcon className="h-4 w-4 text-muted" />
+        </button>
+      </div>
+    </header>
+  )
+}

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,111 @@
+import type { ReactNode } from 'react'
+
+interface IconProps {
+  className?: string
+}
+
+/**
+ * Minimal hand-authored line icons (no icon library dependency yet) —
+ * geometry only, styled entirely by `currentColor` + Tailwind classes.
+ */
+
+function Icon({ className, children }: IconProps & { children: ReactNode }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  )
+}
+
+export function LogoIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M3 10v4a1 1 0 0 0 1 1h2l7 4V5L6 9H4a1 1 0 0 0-1 1Z" />
+      <path d="M18 8a4 4 0 0 1 0 8M21 5a8 8 0 0 1 0 14" />
+    </Icon>
+  )
+}
+
+export function DashboardIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <rect x="3" y="3" width="7" height="7" rx="1" />
+      <rect x="14" y="3" width="7" height="7" rx="1" />
+      <rect x="3" y="14" width="7" height="7" rx="1" />
+      <rect x="14" y="14" width="7" height="7" rx="1" />
+    </Icon>
+  )
+}
+
+export function CartIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <circle cx="9" cy="20" r="1" />
+      <circle cx="18" cy="20" r="1" />
+      <path d="M2 3h2l2.4 12.4a2 2 0 0 0 2 1.6h8.7a2 2 0 0 0 2-1.6L21 7H6" />
+    </Icon>
+  )
+}
+
+export function GlobeIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M3 12h18M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18" />
+    </Icon>
+  )
+}
+
+export function SettingsIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M12 2v3M12 19v3M4.2 4.2l2.1 2.1M17.7 17.7l2.1 2.1M2 12h3M19 12h3M4.2 19.8l2.1-2.1M17.7 6.3l2.1-2.1" />
+    </Icon>
+  )
+}
+
+export function LogoutIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <path d="M16 17l5-5-5-5" />
+      <path d="M21 12H9" />
+    </Icon>
+  )
+}
+
+export function SearchIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <circle cx="11" cy="11" r="7" />
+      <path d="M21 21l-4.35-4.35" />
+    </Icon>
+  )
+}
+
+export function BellIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M6 8a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6" />
+      <path d="M10 20a2 2 0 0 0 4 0" />
+    </Icon>
+  )
+}
+
+export function ChevronDownIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M6 9l6 6 6-6" />
+    </Icon>
+  )
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom'
 
+import { AppShell } from '@/components/AppShell'
 import { CourseDetail } from '@/pages/CourseDetail'
 import { Dashboard } from '@/pages/Dashboard'
 import { Explore } from '@/pages/Explore'
@@ -20,39 +21,24 @@ export const router = createBrowserRouter([
     ),
   },
   {
-    path: '/dashboard',
+    // Single AppShell (sidebar + topbar) wraps every protected route via
+    // Outlet, per Ticket #7's acceptance criteria.
     element: (
       <ProtectedRoute>
-        <Dashboard />
+        <AppShell />
       </ProtectedRoute>
     ),
+    children: [
+      { path: '/dashboard', element: <Dashboard /> },
+      { path: '/purchases', element: <Purchases /> },
+      { path: '/settings', element: <Settings /> },
+      { path: '/courses/:courseId', element: <CourseDetail /> },
+    ],
   },
-  {
-    path: '/purchases',
-    element: (
-      <ProtectedRoute>
-        <Purchases />
-      </ProtectedRoute>
-    ),
-  },
-  // Public catalog browsing — no auth required, matches the login page's
-  // "Explore Online Courses" CTA for guests. Inferred, not spec'd.
+  // Public catalog browsing, outside the shell — no mockup shows an
+  // authenticated /explore with sidebar/topbar (Ticket #7 only covers
+  // "authenticated screens"), and it's reachable while logged out (login
+  // page's "Explore Online Courses" CTA). Revisit alongside Ticket #20.
   { path: '/explore', element: <Explore /> },
-  {
-    path: '/settings',
-    element: (
-      <ProtectedRoute>
-        <Settings />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/courses/:courseId',
-    element: (
-      <ProtectedRoute>
-        <CourseDetail />
-      </ProtectedRoute>
-    ),
-  },
   { path: '/style-guide', element: <StyleGuide /> },
 ])


### PR DESCRIPTION
Closes #7

- `AppShell` (sidebar + topbar + `<Outlet>`) as a single parent route
  wrapping `/dashboard`, `/purchases`, `/settings`, `/courses/:courseId`
  via `<ProtectedRoute><AppShell /></ProtectedRoute>`
- `Sidebar`: active-route highlighting (`NavLink`), logout button wired to
  `useAuth().logout()`
- `Topbar`: search input, language/notification placeholders, user info
  pulled from `useAuth()` — not hardcoded
- Small hand-authored icon set (`src/components/icons.tsx`), no new
  dependency
- Verified: build/typecheck/lint pass, and all routes serve 200 through
  the dev server with `VITE_USE_MOCKS=true`

**Flagged in TODO.md:** `/explore` was kept outside the shell entirely —
none of the 6 provided screenshots show an authenticated Explore page,
and Ticket #7 scopes the shell to "authenticated screens." Worth
revisiting alongside Ticket #20 (Catalog page). Language dropdown and
notification bell are visual placeholders only, as neither i18n switching
nor a notifications feature exists yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qh4T3NXHsA3Zq8j8RTjwYR