### PR TITLE
Maintenance mode + 404 page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,8 @@ VITE_USE_MOCKS=true
 # link) and shows a "coming soon" notice instead. "Explore Online Courses"
 # stays visible either way.
 VITE_IS_COMING_SOON=false
+
+# When "true", every route shows the Maintenance page instead of the app
+# — checked before auth/routing even runs, so it works regardless of
+# backend/session state. Off by default.
+VITE_MAINTENANCE_MODE=false

--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ src/
 - `/explore` — public, outside the shell (see "App shell")
 - `/forgot-password`, `/reset-password?token=...` — public, no design yet
   (see "Forgot / reset password")
-- `/maintenance` — static page, nothing routes here automatically yet (see
-  "Maintenance page")
+- `/maintenance` — shown for every route when `VITE_MAINTENANCE_MODE=true`
+  (see "Maintenance page"); also reachable directly
 - `/style-guide` — palette, type scale, and component reference (Ticket 2/6)
+- `*` (catch-all, public, must stay last) — `NotFound` (404) for any
+  unmatched URL
 
 ## Design tokens
 
@@ -197,9 +199,10 @@ Ticket #3's requirement for the Golang client wrapper.
 
 `src/lib/config.ts` is the **only** place that reads `import.meta.env`.
 Everywhere else imports the exported constant (`IS_COMING_SOON`,
-`USE_MOCKS`) instead of reading `import.meta.env.VITE_*` inline — one
-place for flag names and parsing (`=== 'true'`), so it can't drift between
-call sites. Add new env-derived flags here, not inline in a component.
+`USE_MOCKS`, `MAINTENANCE_MODE`) instead of reading
+`import.meta.env.VITE_*` inline — one place for flag names and parsing
+(`=== 'true'`), so it can't drift between call sites. Add new env-derived
+flags here, not inline in a component.
 
 ## Logo & favicon
 
@@ -334,11 +337,21 @@ criteria are concrete even without a mockup.
 
 ## Maintenance page
 
-`src/pages/Maintenance.tsx` at `/maintenance` — a static "Under
-Maintenance" page. **Nothing routes here automatically** — no ticket
-specifies when/how maintenance mode should trigger (a global env flag
-redirecting every route, a backend 503, etc.), so only the page itself
-exists so far. See `TODO.md`.
+`src/pages/Maintenance.tsx` — shown for the **entire app**, any route,
+when `VITE_MAINTENANCE_MODE=true` (`MAINTENANCE_MODE` in
+`src/lib/config.ts`). Checked in `App.tsx` before `QueryProvider`,
+`AuthProvider`, or the router even mount, so it works regardless of
+backend/session state — it's not just another route. Also reachable
+directly at `/maintenance` regardless of the flag.
+
+## 404 / Not Found
+
+`src/pages/NotFound.tsx` — the catch-all (`path: '*'`, must stay last in
+`src/routes/index.tsx`) for any unmatched URL. Public, not gated by
+`ProtectedRoute`/`GuestOnlyRoute` — an unknown URL isn't "protected
+content," so redirecting to `/login` first would be the wrong behavior.
+"Back to Home" links to `/dashboard`; `ProtectedRoute` sends an
+unauthenticated visitor on to `/login` from there as normal.
 
 ## Git Workflow
 

--- a/TODO.md
+++ b/TODO.md
@@ -243,13 +243,24 @@ the mock handlers.
 style — there's no real design to match yet. Replace once Irene/Marco
 Herbert provide one.
 
-## Maintenance page — built, not wired anywhere
+## Maintenance mode + 404 page: done
 
-Added `src/pages/Maintenance.tsx` at `/maintenance` per your request. It's
-a static page only: no ticket specifies when/how maintenance mode should
-actually trigger (a global env flag redirecting every route here, a
-backend 503 passed through, etc.), so that wiring doesn't exist — nothing
-currently navigates to this route automatically.
+**Status:** done. (Supersedes the earlier "Maintenance page — built, not
+wired anywhere" entry — it's wired now.)
+
+`VITE_MAINTENANCE_MODE=true` shows `Maintenance` for the whole app,
+checked in `App.tsx` before `QueryProvider`/`AuthProvider`/the router
+mount — deliberately not just another route, so it works even if
+auth/API state is broken. `NotFound` (404) is the catch-all route
+(`path: '*'`) for any unmatched URL, public/ungated. Both translated
+(EN/ID, `common.maintenance.*` / `common.notFound.*`) — verified
+`en.json`/`id.json` still have identical key sets.
+
+**Not addressed (out of scope, wasn't asked):** what a real backend 503
+should do (currently nothing translates a failed API response into
+maintenance mode — it's purely the env flag), and there's still no route
+for `/` itself (unmatched, so it currently hits `NotFound` too) — worth a
+decision on what `/` should redirect to.
 
 ## Ticket #10 — Register page: done, with explicit approvals from you
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,19 @@
 import { RouterProvider } from 'react-router-dom'
 
+import { MAINTENANCE_MODE } from '@/lib/config'
+import { Maintenance } from '@/pages/Maintenance'
 import { AuthProvider } from '@/providers/AuthProvider'
 import { QueryProvider } from '@/providers/QueryProvider'
 import { router } from '@/routes'
 
 function App() {
+  // Checked before QueryProvider/AuthProvider/the router even mount, so
+  // maintenance mode doesn't depend on — and isn't blocked by — auth or
+  // API state. See README "Maintenance page".
+  if (MAINTENANCE_MODE) {
+    return <Maintenance />
+  }
+
   return (
     <QueryProvider>
       <AuthProvider>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,3 +10,6 @@ export const USE_MOCKS = import.meta.env.VITE_USE_MOCKS === 'true'
 
 /** Hides the Login page's sign-in form/sign-up link. See README "Login page". */
 export const IS_COMING_SOON = import.meta.env.VITE_IS_COMING_SOON === 'true'
+
+/** When true, the whole app shows the Maintenance page instead of routing normally. See README "Maintenance page". */
+export const MAINTENANCE_MODE = import.meta.env.VITE_MAINTENANCE_MODE === 'true'

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,4 +1,16 @@
 {
+  "common": {
+    "maintenance": {
+      "heading": "Under Maintenance",
+      "body": "We're making some improvements and will be back shortly. Thanks for your patience."
+    },
+    "notFound": {
+      "code": "404",
+      "heading": "Page not found",
+      "body": "The page you're looking for doesn't exist or may have been moved.",
+      "backHome": "Back to Home"
+    }
+  },
   "auth": {
     "comingSoon": {
       "heading": "We're coming soon",

--- a/src/messages/id.json
+++ b/src/messages/id.json
@@ -1,4 +1,16 @@
 {
+  "common": {
+    "maintenance": {
+      "heading": "Sedang Dalam Perbaikan",
+      "body": "Kami sedang melakukan peningkatan dan akan segera kembali. Terima kasih atas kesabaran Anda."
+    },
+    "notFound": {
+      "code": "404",
+      "heading": "Halaman tidak ditemukan",
+      "body": "Halaman yang Anda cari tidak ada atau mungkin telah dipindahkan.",
+      "backHome": "Kembali ke Beranda"
+    }
+  },
   "auth": {
     "comingSoon": {
       "heading": "Segera hadir",

--- a/src/pages/Maintenance.tsx
+++ b/src/pages/Maintenance.tsx
@@ -1,19 +1,20 @@
+import { useTranslation } from 'react-i18next'
+
 import { Logo } from '@/components/Logo'
 
 /**
- * Static page only — nothing routes here automatically yet. No ticket
- * specifies when/how maintenance mode should be triggered (a global env
- * flag redirecting every route here, a backend 503, etc.), so that wiring
- * isn't built. See TODO.md.
+ * Shown for the whole app when VITE_MAINTENANCE_MODE=true (see App.tsx /
+ * src/lib/config.ts) — checked before routing/auth, so it works
+ * regardless of backend/session state.
  */
 export function Maintenance() {
+  const { t } = useTranslation()
+
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
       <Logo className="h-16 w-auto" />
-      <h1 className="text-display font-bold">Under Maintenance</h1>
-      <p className="text-muted max-w-md">
-        We&apos;re making some improvements and will be back shortly. Thanks for your patience.
-      </p>
+      <h1 className="text-display font-bold">{t('common.maintenance.heading')}</h1>
+      <p className="text-muted max-w-md">{t('common.maintenance.body')}</p>
     </div>
   )
 }

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,22 @@
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+
+import { Button } from '@/components/Button'
+import { Logo } from '@/components/Logo'
+
+/** Catch-all for any unmatched route (src/routes/index.tsx, path: '*'). */
+export function NotFound() {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
+      <Logo className="h-16 w-auto" />
+      <p className="text-primary text-stat font-bold">{t('common.notFound.code')}</p>
+      <h1 className="text-h2 font-bold">{t('common.notFound.heading')}</h1>
+      <p className="text-muted max-w-md">{t('common.notFound.body')}</p>
+      <Link to="/dashboard" className="mt-2">
+        <Button variant="primary">{t('common.notFound.backHome')}</Button>
+      </Link>
+    </div>
+  )
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,6 +7,7 @@ import { Explore } from '@/pages/Explore'
 import { ForgotPassword } from '@/pages/ForgotPassword'
 import { Login } from '@/pages/Login'
 import { Maintenance } from '@/pages/Maintenance'
+import { NotFound } from '@/pages/NotFound'
 import { Purchases } from '@/pages/Purchases'
 import { Register } from '@/pages/Register'
 import { ResetPassword } from '@/pages/ResetPassword'
@@ -58,4 +59,7 @@ export const router = createBrowserRouter([
   { path: '/reset-password', element: <ResetPassword /> },
   { path: '/maintenance', element: <Maintenance /> },
   { path: '/style-guide', element: <StyleGuide /> },
+  // Catch-all — must stay last. Public, not gated: an unmatched URL isn't
+  // "protected content," so redirecting to /login first would be wrong.
+  { path: '*', element: <NotFound /> },
 ])

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,8 @@ interface ImportMetaEnv {
   readonly VITE_USE_MOCKS: string
   /** When "true", hides sign-in options on the Login page. See README "Login page". */
   readonly VITE_IS_COMING_SOON: string
+  /** When "true", the whole app shows the Maintenance page instead of routing normally. See README "Maintenance page". */
+  readonly VITE_MAINTENANCE_MODE: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
- **Maintenance mode**: `VITE_MAINTENANCE_MODE=true` shows the
  `Maintenance` page for the entire app, checked in `App.tsx` before
  `QueryProvider`/`AuthProvider`/the router mount — so it works even if
  auth/API state is completely broken, not just another route.
  Translated (EN/ID).
- **404 page**: `NotFound` as the catch-all route (`path: '*'`,
  public/ungated — an unmatched URL isn't protected content). "Back to
  Home" links to `/dashboard`. Translated (EN/ID).
- Verified: `en.json`/`id.json` still have identical key sets (69 each),
  build/typecheck/lint clean, and both flags smoke-tested through the
  dev server (maintenance on/off, an unmatched route).

**Flagged in TODO.md, not addressed (wasn't asked):** there's still no
route for `/` itself — it currently falls through to `NotFound` too —
and nothing yet translates a real backend 503 into maintenance mode
(it's purely the env flag for now).

Branched from `master` — independent of the still-unmerged #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qh4T3NXHsA3Zq8j8RTjwYR