### PR TITLE
Fix pnpm install failing on Vercel (msw build script)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ only. Edit `.env.local` (gitignored, per-machine) instead.
 pnpm only. Don't commit `package-lock.json` or `yarn.lock` — `pnpm-lock.yaml`
 is the single lockfile for this repo.
 
+`pnpm-workspace.yaml`'s `allowBuilds: { msw: true }` lets `msw`'s
+postinstall script run. Without it, pnpm 11 blocks unapproved dependency
+build scripts and **`pnpm install` exits 1** (not just a warning) —
+this broke the Vercel build. If a new dependency ever needs its build
+script approved, add it here rather than running `pnpm approve-builds`
+interactively (that doesn't persist anywhere CI can see it).
+
 ## Project structure
 
 ```

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  msw: true


### PR DESCRIPTION
**Root cause:** pnpm 11 blocks unapproved dependency build/postinstall
scripts by default. Locally this only warns
(\`[ERR_PNPM_IGNORED_BUILDS]\`), but I reproduced it exactly: a clean
\`node_modules\` + \`pnpm install\` (and \`--frozen-lockfile\`, Vercel's
typical install command) **exits 1**, not 0 — which is exactly the
Vercel failure reported.

**Fix:** \`pnpm-workspace.yaml\` with \`allowBuilds: { msw: true }\` —
the old \`package.json\` \`"pnpm"\` field is no longer read by this pnpm
version; the setting moved. Verified clean-install + \`--frozen-lockfile\`
both exit 0 now, and typecheck/lint/build all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qh4T3NXHsA3Zq8j8RTjwYR