### PR TITLE
Fix /login 404 on Vercel + add / root redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ this broke the Vercel build. If a new dependency ever needs its build
 script approved, add it here rather than running `pnpm approve-builds`
 interactively (that doesn't persist anywhere CI can see it).
 
+## Deployment (Vercel)
+
+`vercel.json` rewrites every path to `/index.html` — required for a
+client-side-routed SPA on Vercel's static hosting. Without it, a direct
+visit or refresh on any route other than `/` (e.g. `/login`) 404s: Vercel
+looks for a matching static file/function for that exact path, finds
+none, and never gets a chance to hand off to React Router client-side.
+Don't remove this file.
+
 ## Project structure
 
 ```
@@ -62,6 +71,10 @@ src/
 
 ## Routes
 
+- `/` — redirects straight to `/login`, which handles both cases:
+  `GuestOnlyRoute` forwards an already-authenticated visitor on to
+  `/dashboard`, and an unauthenticated one sees the coming-soon-locked
+  form when `IS_COMING_SOON` is true.
 - `/login`, `/register` — guest-only (redirect to `/dashboard` if already
   authenticated); `/register` has no design yet (see "Register page")
 - `/dashboard`, `/purchases`, `/settings`, `/courses/:courseId` — protected,

--- a/TODO.md
+++ b/TODO.md
@@ -258,9 +258,33 @@ auth/API state is broken. `NotFound` (404) is the catch-all route
 
 **Not addressed (out of scope, wasn't asked):** what a real backend 503
 should do (currently nothing translates a failed API response into
-maintenance mode — it's purely the env flag), and there's still no route
-for `/` itself (unmatched, so it currently hits `NotFound` too) — worth a
-decision on what `/` should redirect to.
+maintenance mode — it's purely the env flag).
+
+**Update:** the "no route for `/`" gap above is resolved — `/` now
+redirects to `/login`, see the "Deployment / root route" entry below.
+
+## Vercel deploy fixes: /login 404 in production, root route missing
+
+**Status:** done.
+
+Two related production bugs reported after deploying:
+
+1. **`/login` (and any direct/refreshed route) 404'd on Vercel.** Cause:
+   Vercel's static hosting looks for a file/function matching the exact
+   path and 404s if none exists — it never got a chance to serve
+   `index.html` so React Router could take over client-side. Fixed with
+   `vercel.json`'s catch-all rewrite (`/(.*)` → `/index.html`). This is
+   Vercel-specific — local dev/`vite preview` never hit this because both
+   already fall back to `index.html` for unmatched paths on their own.
+2. **No route existed for `/` itself** — it fell through to the
+   `NotFound` catch-all, same underlying gap noted in the Maintenance
+   entry above. Added `{ path: '/', element: <Navigate to="/login" replace /> }`.
+   Per your instruction ("when coming soon, reroute to /login for users
+   that landed in root"): redirecting to `/login` handles this correctly
+   without any extra coming-soon-specific logic, since `/login` already
+   does the right thing in every case — `GuestOnlyRoute` forwards an
+   authenticated visitor on to `/dashboard`, and an unauthenticated one
+   sees the coming-soon-locked form when `IS_COMING_SOON` is true.
 
 **Correction (same PR, before merge):** initially also added a
 `/maintenance` route in `routes/index.tsx` alongside the `App.tsx`

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from 'react-router-dom'
+import { createBrowserRouter, Navigate } from 'react-router-dom'
 
 import { AppShell } from '@/components/AppShell'
 import { CourseDetail } from '@/pages/CourseDetail'
@@ -16,6 +16,11 @@ import { GuestOnlyRoute } from '@/routes/GuestOnlyRoute'
 import { ProtectedRoute } from '@/routes/ProtectedRoute'
 
 export const router = createBrowserRouter([
+  // Root has no page of its own — send everyone through /login, which
+  // already does the right thing either way: GuestOnlyRoute forwards an
+  // authenticated visitor on to /dashboard, and an unauthenticated one
+  // sees the coming-soon-locked form when IS_COMING_SOON is true.
+  { path: '/', element: <Navigate to="/login" replace /> },
   {
     path: '/login',
     element: (

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
**\`/login\` 404 on deployment:** Vercel's static hosting 404s any
direct/refreshed route because it looks for a matching file/function for
that exact path and never hands off to React Router. Fixed with
\`vercel.json\`'s catch-all rewrite (\`/(.*)\` → \`/index.html\`).
Vercel-specific — local dev/\`vite preview\` never hit this since both
already fall back to \`index.html\` on their own, which is why it wasn't
caught earlier.

**Root route:** \`/\` had no route at all (fell through to \`NotFound\`).
Added \`{ path: '/', element: <Navigate to="/login" replace /> }\` — per
your instruction, this handles the coming-soon case with no extra logic:
\`/login\` already does the right thing either way (\`GuestOnlyRoute\`
forwards an authenticated visitor to \`/dashboard\`; an unauthenticated
one sees the coming-soon-locked form when \`IS_COMING_SOON\` is true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qh4T3NXHsA3Zq8j8RTjwYR