### PR TITLE
Always show Explore Online Courses on Login

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,11 +306,12 @@ when `IS_COMING_SOON` is true (see "Config") — the form itself, its
 fields, and cross-links (Sign up, Forgot Password?) stay visible; only
 the submit button is disabled (`disabled={isSubmitting || IS_COMING_SOON}`).
 It's a message-plus-disabled-action, not a replacement for the whole
-form. **Separately**, secondary navigation _outside_ the form is hidden —
-Login's "Explore Online Courses" and Forgot Password's "Back to Sign
-In" — for a full lockdown rather than leaving one working link on an
-otherwise disabled page (Ticket #43; reverses Ticket #9's original
-"stays visible either way").
+form. Secondary navigation _outside_ the form: Login's "Explore Online
+Courses" is **always visible**, coming soon or not — per your explicit
+correction, restoring Ticket #9's original "stays visible either way"
+(Ticket #43 had briefly hidden it for a "full lockdown," reverted).
+Forgot Password's "Back to Sign In" **is still hidden** during coming
+soon — inconsistent with Explore now, not yet revisited; see `TODO.md`.
 
 ## Login page
 
@@ -321,9 +322,10 @@ through `useAuth().login()`; a 401 (`InvalidCredentialsError`) shows a
 generic "Invalid email or password" message, any other failure shows a
 generic error, and success navigates to `/dashboard`.
 
-- **`VITE_IS_COMING_SOON`** (via `src/lib/config.ts`): `"true"` hides the
-  sign-in form, sign-up link, and "Explore Online Courses", showing
-  `ComingSoonNotice` instead (see "Auth layout & coming soon").
+- **`VITE_IS_COMING_SOON`** (via `src/lib/config.ts`): `"true"` shows
+  `ComingSoonNotice` inside the form and disables Sign In — the fields
+  and "Explore Online Courses" stay visible (see "Auth layout & coming
+  soon").
 - **Promo panel content is hardcoded** — Ticket #9 itself flags this as
   needing confirmation ("confirm with Irene whether this is hardcoded or
   should eventually come from Strapi `site_config`"), unresolved, see

--- a/TODO.md
+++ b/TODO.md
@@ -424,9 +424,22 @@ catalog page is Ticket #20's scope, not this one.
 Login/Register/Forgot Password. Now it renders _inside_ the form (where
 the error message goes) and only the submit button is disabled
 (`isSubmitting || IS_COMING_SOON`) — the fields and cross-links stay
-visible and usable-looking, just can't actually be submitted. This does
-not change the earlier decision to hide Explore/Back-to-Sign-In
-(secondary nav _outside_ the form) during coming soon — that stays as-is.
+visible and usable-looking, just can't actually be submitted.
+
+## Un-hid "Explore Online Courses" during coming soon
+
+**Status:** done, per your explicit correction.
+
+Ticket #43 had hidden Login's "Explore Online Courses" during coming soon
+for a "full lockdown." You corrected that — it should stay visible. Fully
+reverted to Ticket #9's original behavior: the button is now unconditional
+in `Login.tsx`, no `IS_COMING_SOON` check.
+
+**Inconsistency now on the table, not yet resolved:** Forgot Password's
+"Back to Sign In" is still hidden during coming soon (same original #43
+logic, untouched since you only mentioned Explore). Worth deciding
+whether it should also always show, for the same reason — flagging
+rather than silently changing a second thing you didn't ask about.
 
 ## Incident: working tree corruption mid-session (informational only)
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -145,13 +145,11 @@ export function Login() {
         </div>
       </form>
 
-      {IS_COMING_SOON ? null : (
-        <Link to="/explore" className="mt-5 block">
-          <Button variant="outline" className="w-full">
-            {t('auth.login.exploreCourses')}
-          </Button>
-        </Link>
-      )}
+      <Link to="/explore" className="mt-5 block">
+        <Button variant="outline" className="w-full">
+          {t('auth.login.exploreCourses')}
+        </Button>
+      </Link>
     </AuthLayout>
   )
 }


### PR DESCRIPTION
Reverts Ticket #43's "hide during coming soon" for Login's "Explore
Online Courses" button, per your correction — it's unconditional again,
restoring Ticket #9's original "stays visible either way."

Flagged in TODO.md rather than silently changed: Forgot Password's "Back
to Sign In" is still hidden during coming soon (same original logic,
untouched since only Explore was mentioned) — worth a decision on
whether that should change too, for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qh4T3NXHsA3Zq8j8RTjwYR